### PR TITLE
Listen for script_raised_built and script_raised_destroy events

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -27,3 +27,13 @@ script.on_configuration_changed(ON_CONFIGURATION_CHANGED)
 script.on_event(defines.events.on_tick,ON_TICK)
 script.on_event({defines.events.on_built_entity,defines.events.on_robot_built_entity},ON_BUILT)
 script.on_event({defines.events.on_pre_player_mined_item,defines.events.on_robot_pre_mined,defines.events.on_entity_died},ON_REMOVE)
+script.on_event(defines.events.script_raised_built, function(event)
+	if event.created_entity and event.created_entity.valid then
+		ON_BUILT(event)
+	end
+end)
+script.on_event(defines.events.script_raised_destroy, function(event)
+	if event.entity and event.entity.valid then
+		ON_REMOVE(event)
+	end
+end)


### PR DESCRIPTION
Hey! I've got a new [mod](https://mods.factorio.com/mod/train-scaling) that builds trains automatically - it has a compatibility problem with your train mods since they need to track their entities for refilling their energy.

This change lets your mod catch the events thrown by mine when it's building trains to solve this compatibility issue - it's the same for both Electric and Fusion trains.