### PR TITLE
 Make power providers work as intended

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.16.12
+Date: 26. 10. 2018
+  Bugfixes:
+    - Next attempt to fix the error. https://mods.factorio.com/mod/ElectricTrain/discussion/5b97a7ae21a58d000969be25
+---------------------------------------------------------------------------------------------------
 Version: 0.16.11
 Date: 08. 10. 2018
   Bugfixes:
@@ -12,12 +17,12 @@ Date: 08. 10. 2018
 Version: 0.16.9
 Date: 27. 09. 2018
   Bugfixes:
-    - Try to fix the bug. https://mods.factorio.com/mod/ElectricTrain/discussion/5b97a7ae21a58d000969be25
+    - Attempt to fix the error. https://mods.factorio.com/mod/ElectricTrain/discussion/5b97a7ae21a58d000969be25
 ---------------------------------------------------------------------------------------------------
 Version: 0.16.8
 Date: 16. 08. 2018
   Bugfixes:
-    - The next try to fix the bug. https://mods.factorio.com/mod/ElectricTrain/discussion/5b68a354a16c56000abd2fe7
+    - Next attempt to fix the error. https://mods.factorio.com/mod/ElectricTrain/discussion/5b68a354a16c56000abd2fe7
 ---------------------------------------------------------------------------------------------------
 Version: 0.16.7
 Date: 07. 08. 2018
@@ -67,7 +72,7 @@ Version: 0.15.11
 ---------------------------------------------------------------------------------------------------
 Version: 0.15.10
   Bugfixes:
-    - The next try to fix my mistake. https://mods.factorio.com/mod/ElectricTrain/discussion/5a5f1b0dadcc441024d76eb3
+    - Next attempt to fix my mistake. https://mods.factorio.com/mod/ElectricTrain/discussion/5a5f1b0dadcc441024d76eb3
 ---------------------------------------------------------------------------------------------------
 Version: 0.15.9
   Bugfixes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.16.13
+Date: 15. 03. 2019
+  Changes:
+    - Resolving the problem that one power provider can keep any number of trains operating at full capacity.
+    - Resolving the problem that provider energy can drop below zero.
+    - Resolving the problem that remaining burner fuel can increase above maximum fuel energy.
+    - Both electric power and energy from burning fuel are conserved when switching power sources.
+---------------------------------------------------------------------------------------------------
 Version: 0.16.12
 Date: 26. 10. 2018
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
 	"name":"ElectricTrain",
 	"author":"magu5026",
-	"version":"0.16.11",
+	"version":"0.16.12",
 	"title":"Electric Train",
 	"description":"Adds electric locomotives to the game.",
 	"factorio_version":"0.16",

--- a/lib.lua
+++ b/lib.lua
@@ -1,4 +1,4 @@
-function NeedMigration(data,modname)
+function IsModChanged(data,modname)
 	if data 
 	 and data.mod_changes 
 	 and data.mod_changes[modname] 

--- a/lua/basic_event_handler.lua
+++ b/lua/basic_event_handler.lua
@@ -3,9 +3,8 @@ require("lib")
 
 local function _Init()
 	global.TrainList = global.TrainList or {}
-	global.TrainCount = global.TrainCount or 0
 	global.ProviderList = global.ProviderList or {}
-	global.ProviderCount = global.ProviderCount or 0
+	global.Fuel = global.Fuel or game.item_prototypes['et-electric-locomotive-fuel']
 end
 
 
@@ -18,37 +17,27 @@ function OnConfigurationChanged(data)
 	_Init()
 
 	local mod_name = "ElectricTrain"
-	if NeedMigration(data,mod_name) then
-		local old_version = GetOldVersion(data,mod_name)
-		if old_version < "00.16.09" then
-			global = {}
-			global.TrainList = {}
-			global.ProviderList = {} 
-			global.TrainCount = 0
-			global.ProviderCount = 0	
-						
-			for _,surface in pairs(game.surfaces) do
-				local trains = surface.find_entities_filtered{type="locomotive"}
-				for _,train in pairs(trains) do
-					if train.name:find("et-electric-locomotive-mk",1,true) then
-						table.insert(global.TrainList,{entity = train, last_fuel = {}})
-												
-						local fuel = game.item_prototypes['et-electric-locomotive-fuel']
-						train.burner.currently_burning = fuel
-						train.burner.remaining_burning_fuel = fuel.fuel_value
-					end
-				end	
-
-				local providers = surface.find_entities_filtered{type="electric-energy-interface"}
-				for _,provider in pairs(providers) do
-					if provider.name == "et-electricity-provider" then
-						table.insert(global.ProviderList,provider)
-					end
-				end	
-			end
-			
-			global.TrainCount = Count(global.TrainList)
-			global.ProviderCount = Count(global.ProviderList)
+	if IsModChanged(data,mod_name) then
+		global = {}
+		global.TrainList = {}
+		global.ProviderList = {} 
+		global.Fuel = game.item_prototypes['et-electric-locomotive-fuel']
+		
+		for _,surface in pairs(game.surfaces) do
+			local trains = surface.find_entities_filtered{type="locomotive"}
+			for _,train in pairs(trains) do
+				if train.name:find("et-electric-locomotive-mk",1,true) then
+					table.insert(global.TrainList,{entity = train, last_fuel = {}})
+					train.burner.currently_burning = global.Fuel
+					train.burner.remaining_burning_fuel = global.Fuel.fuel_value
+				end
+			end	
+			local providers = surface.find_entities_filtered{type="electric-energy-interface"}
+			for _,provider in pairs(providers) do
+				if provider.name == "et-electricity-provider" then
+					table.insert(global.ProviderList,provider)
+				end
+			end	
 		end
 	end
 end

--- a/lua/basic_event_handler.lua
+++ b/lua/basic_event_handler.lua
@@ -27,7 +27,7 @@ function OnConfigurationChanged(data)
 			local trains = surface.find_entities_filtered{type="locomotive"}
 			for _,train in pairs(trains) do
 				if train.name:find("et-electric-locomotive-mk",1,true) then
-					table.insert(global.TrainList,{entity = train, last_fuel = {}})
+					table.insert(global.TrainList,{entity = train, last_fuel = nil, last_fuel_value = 0, stored_energy = 0})
 					train.burner.currently_burning = global.Fuel
 					train.burner.remaining_burning_fuel = global.Fuel.fuel_value
 				end

--- a/lua/logic_event_handler.lua
+++ b/lua/logic_event_handler.lua
@@ -7,7 +7,7 @@ function OnBuilt(event)
 		if entity.name == "et-electricity-provider" and entity.type == "electric-energy-interface" then
 			table.insert(global.ProviderList,entity)
 		elseif entity.name:find("et-electric-locomotive-mk",1,true) and entity.type == "locomotive" then 
-			table.insert(global.TrainList,{entity = entity, last_fuel = {}})
+			table.insert(global.TrainList,{entity = entity, last_fuel = nil, last_fuel_value = 0, stored_energy = 0})
 			entity.burner.currently_burning = global.Fuel
 			entity.burner.remaining_burning_fuel = global.Fuel.fuel_value
 		end
@@ -37,76 +37,87 @@ function OnRemove(event)
 end
 
 
-local function _ChangeTrainFuel()
-	for i,train in pairs(global.TrainList) do
-		if train and train.entity and train.entity.valid then
-			if train.entity.burner.currently_burning == global.Fuel then
-				train.entity.burner.currently_burning = nil
-				if train.last_fuel.fuel then
-					train.entity.burner.currently_burning = train.last_fuel.fuel
-					train.entity.burner.remaining_burning_fuel = train.last_fuel.fuel_value
-				end
-			end
+function OnTick()
+	if #global.TrainList == 0 then
+		return
+	end
+
+	local provider_energy  = 0
+
+	for i,provider in pairs(global.ProviderList) do
+		if provider and provider.valid then
+			provider_energy = provider_energy + provider.energy
+		else
+			table.remove(global.ProviderList,i)
 		end
 	end
-end
-	
-	
-function OnTick()
-	if #global.TrainList > 0 and #global.ProviderList > 0 then
-		local need_power = 0
-		local provider_power = 0
-		local rest_power = 0
-		local split_power = 0
-		
-		for i,provider in pairs(global.ProviderList) do
-			if provider and provider.valid then
-				provider_power = provider_power + provider.energy
-			else
-				table.remove(global.ProviderList,i)
+
+	local available_energy = provider_energy * 0.1
+	local need_energy = 0
+	local Fuel = global.Fuel
+	local fuel_value = Fuel.fuel_value
+
+	for i,train in pairs(global.TrainList) do
+		if train and train.entity and train.entity.valid then
+			local burner = train.entity.burner
+			local currently_burning = burner.currently_burning
+			local remaining_fuel = burner.remaining_burning_fuel
+			local stored_energy = train.stored_energy or 0
+
+			if currently_burning ~= Fuel then
+				train.last_fuel = currently_burning
+				train.last_fuel_value = remaining_fuel
+				burner.currently_burning = Fuel
+				remaining_fuel = 0
 			end
-		end
-			
-		if provider_power > 0 then 
-			for i,train in pairs(global.TrainList) do
-				if train and train.entity and train.entity.valid then
-					if not train.entity.burner.currently_burning or train.entity.burner.currently_burning ~= global.Fuel then
-						train.last_fuel['fuel'] = train.entity.burner.currently_burning
-						train.last_fuel['fuel_value'] = train.entity.burner.remaining_burning_fuel
-				
-						train.entity.burner.currently_burning = global.Fuel
-						train.entity.burner.remaining_burning_fuel = global.Fuel.fuel_value
-					end
-					need_power = need_power + global.Fuel.fuel_value - train.entity.burner.remaining_burning_fuel				
-				else
-					table.remove(global.TrainList,i)
-				end
+
+			remaining_fuel = remaining_fuel + stored_energy
+
+			if remaining_fuel > fuel_value then
+				remaining_fuel = fuel_value
 			end
-		
-			rest_power = provider_power - need_power
-			if rest_power >= 0 then
-				for _,train in pairs(global.TrainList) do
-					train.entity.burner.remaining_burning_fuel = global.Fuel.fuel_value
-				end
-				split_power = rest_power / #global.ProviderList
-				for _,provider in pairs(global.ProviderList) do
-					provider.energy = split_power
-				end
-			else
-				for _,provider in pairs(global.ProviderList) do
-					provider.energy = 0
-				end
-				split_power = provider_power / #global.TrainList
-				for _,train in pairs(global.TrainList) do
-					train.entity.burner.remaining_burning_fuel = train.entity.burner.remaining_burning_fuel + split_power
-				end
-			end
+
+                        need_energy = need_energy + fuel_value - remaining_fuel
+
+			burner.remaining_burning_fuel = remaining_fuel
+			train.stored_energy = 0
 		else
-			_ChangeTrainFuel()
+			table.remove(global.TrainList,i)
+		end
+	end
+
+	if available_energy > need_energy then
+		for _,train in pairs(global.TrainList) do
+			train.entity.burner.remaining_burning_fuel = fuel_value
+		end
+		local remainder_ratio = 1 - (need_energy / provider_energy)
+		for _,provider in pairs(global.ProviderList) do
+			provider.energy = remainder_ratio * provider.energy
 		end
 	else
-		if #global.TrainList > 0 and #global.ProviderList == 0 then
-			_ChangeTrainFuel()
+		local remainder_ratio = 1 - (available_energy / provider_energy)
+		for _,provider in pairs(global.ProviderList) do
+			provider.energy = remainder_ratio * provider.energy
+		end
+		local minimum_fuel = 0.1 * fuel_value
+		local available_ratio = available_energy / need_energy
+		for _,train in pairs(global.TrainList) do
+			local burner = train.entity.burner
+			local remaining_fuel = burner.remaining_burning_fuel
+			remaining_fuel = remaining_fuel + available_ratio * (fuel_value - remaining_fuel)
+			if remaining_fuel >= minimum_fuel then
+				burner.remaining_burning_fuel = remaining_fuel
+			else
+				train.stored_energy = remaining_fuel
+				if train.last_fuel then
+					burner.currently_burning = train.last_fuel
+					burner.remaining_burning_fuel = train.last_fuel_value
+					train.last_fuel = nil
+				else
+					burner.currently_burning = nil
+					burner.remaining_burning_fuel = 0
+				end
+			end
 		end
 	end
 end

--- a/lua/logic_event_handler.lua
+++ b/lua/logic_event_handler.lua
@@ -42,7 +42,7 @@ function OnTick()
 		return
 	end
 
-	local provider_energy  = 0
+	local provider_energy = 0
 
 	for i,provider in pairs(global.ProviderList) do
 		if provider and provider.valid then
@@ -71,16 +71,18 @@ function OnTick()
 				remaining_fuel = 0
 			end
 
-			remaining_fuel = remaining_fuel + stored_energy
+			if stored_energy > 0 then
+				remaining_fuel = remaining_fuel + stored_energy
+				burner.remaining_burning_fuel = remaining_fuel
+				train.stored_energy = 0
+			end
 
 			if remaining_fuel > fuel_value then
 				remaining_fuel = fuel_value
+				burner.remaining_burning_fuel = remaining_fuel
 			end
 
                         need_energy = need_energy + fuel_value - remaining_fuel
-
-			burner.remaining_burning_fuel = remaining_fuel
-			train.stored_energy = 0
 		else
 			table.remove(global.TrainList,i)
 		end

--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -62,6 +62,6 @@ data:extend({ppro})
 local fuel = table.deepcopy(data.raw['item']['raw-wood'])
 fuel.name = "et-electric-locomotive-fuel"
 fuel.flags = {"hidden"}
-fuel.fuel_value = "10GJ"
-	
+fuel.fuel_value = "1MJ"
+
 data:extend({fuel})


### PR DESCRIPTION
Fixes the issue that a single power provider is enough to operate any number of trains at full capacity, regardless of the amount of energy "burned" by the trains.

The expectation is that trains should burn alternative fuel, if available, or else operate at reduced capacity when there are not enough power providers to keep up with the power the consumed by the trains. In practice, however, while an insufficient number of power providers does limit the amount of "electric fuel" placed in the trains at each tick, the trains continue to operate at full capacity so long as there is _any_ fuel remaining.

The change proposed here is to assign each train a 1MJ buffer (one "electric fuel"—reduced from the original 10GJ fuel value). These buffers, which are initially fully discharged, are filled from the power providers in proportion to the amount of energy needed to top off each train[1], up to a maximum of 10% of the total provider energy per tick. Whenever the buffer is less than 10% charged the "electric fuel" is removed from the burner. The removed energy is stored in a separate field until the next tick and accumulates until it reaches 10%, which allows the trains to operate at reduced capacity; with 1/3 of the needed providers, for example, each train will be supplied with "electric fuel" one tick out of every three, on average—assuming constant power draw—and spend the other two ticks either burning normal fuel or drifting while the buffer charges.

Testing the changes with my own base shows about 60MW total power draw from the 30-40 power providers needed to keep my trains supplied (a few dozen MK3s). Before this change I was running the same trains from a single power provider drawing a constant 2.1MW with no noticeable difference in train performance, which means the system was generating about 48MW of free energy.

Overall there is more code in the OnTick function, but since I also extracted some of the common subexpressions to local variables (e.g. global.Fuel.fuel_value & train.entity.burner) the CPU utilization has actually decreased compared to the original version. It's still fairly high—3ms per tick for my base, which is much higher than any other mods I have enabled—but as I recall the original code was using 10ms. I experimented with only running the OnTick handler one tick out of 10; while that did appear to work well enough, and increased my UPS by about 30%, it also caused the power draw to pulsate, so in the end I reverted back to processing on every tick.

[1] Originally the total provider energy was divided equally among all trains, but this can cause the energy remaining in the burner to exceed the maximum energy in one unit of "fuel". For example, consider the case where there is one train with a full burner and other trains in need of energy; if the same amount of energy is added to all the trains then the first one will be overfilled. For the same reason, energy is now drawn from power providers in proportion to each provider's stored energy rather than taking the same average energy from all providers, which could potentially result in _negative_ energy.